### PR TITLE
Fix text selection colors for iTerm2

### DIFF
--- a/terminals/iterm2/cosmic_latte_dark.itermcolors
+++ b/terminals/iterm2/cosmic_latte_dark.itermcolors
@@ -1,259 +1,259 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>Ansi 0 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.19215686274509805</real>
-		<key>Green Component</key>
-		<real>0.16470588235294117</real>
-		<key>Red Component</key>
-		<real>0.12549019607843137</real>
-	</dict>
-	<key>Ansi 1 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.5529411764705883</real>
-		<key>Green Component</key>
-		<real>0.4823529411764706</real>
-		<key>Red Component</key>
-		<real>0.7568627450980392</real>
-	</dict>
-	<key>Ansi 10 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.3803921568627451</real>
-		<key>Green Component</key>
-		<real>0.592156862745098</real>
-		<key>Red Component</key>
-		<real>0.49019607843137253</real>
-	</dict>
-	<key>Ansi 11 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.3803921568627451</real>
-		<key>Green Component</key>
-		<real>0.5294117647058824</real>
-		<key>Red Component</key>
-		<real>0.6980392156862745</real>
-	</dict>
-	<key>Ansi 12 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7411764705882353</real>
-		<key>Green Component</key>
-		<real>0.5882352941176471</real>
-		<key>Red Component</key>
-		<real>0.32941176470588235</real>
-	</dict>
-	<key>Ansi 13 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7333333333333333</real>
-		<key>Green Component</key>
-		<real>0.5215686274509804</real>
-		<key>Red Component</key>
-		<real>0.6078431372549019</real>
-	</dict>
-	<key>Ansi 14 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.5647058823529412</real>
-		<key>Green Component</key>
-		<real>0.615686274509804</real>
-		<key>Red Component</key>
-		<real>0.27058823529411763</real>
-	</dict>
-	<key>Ansi 15 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.8588235294117647</real>
-		<key>Green Component</key>
-		<real>0.796078431372549</real>
-		<key>Red Component</key>
-		<real>0.7725490196078432</real>
-	</dict>
-	<key>Ansi 2 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.3803921568627451</real>
-		<key>Green Component</key>
-		<real>0.592156862745098</real>
-		<key>Red Component</key>
-		<real>0.49019607843137253</real>
-	</dict>
-	<key>Ansi 3 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.3803921568627451</real>
-		<key>Green Component</key>
-		<real>0.5294117647058824</real>
-		<key>Red Component</key>
-		<real>0.6980392156862745</real>
-	</dict>
-	<key>Ansi 4 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7411764705882353</real>
-		<key>Green Component</key>
-		<real>0.5882352941176471</real>
-		<key>Red Component</key>
-		<real>0.32941176470588235</real>
-	</dict>
-	<key>Ansi 5 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7333333333333333</real>
-		<key>Green Component</key>
-		<real>0.5215686274509804</real>
-		<key>Red Component</key>
-		<real>0.6078431372549019</real>
-	</dict>
-	<key>Ansi 6 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.5647058823529412</real>
-		<key>Green Component</key>
-		<real>0.615686274509804</real>
-		<key>Red Component</key>
-		<real>0.27058823529411763</real>
-	</dict>
-	<key>Ansi 7 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7529411764705882</real>
-		<key>Green Component</key>
-		<real>0.6901960784313725</real>
-		<key>Red Component</key>
-		<real>0.6705882352941176</real>
-	</dict>
-	<key>Ansi 8 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.6196078431372549</real>
-		<key>Green Component</key>
-		<real>0.5607843137254902</real>
-		<key>Red Component</key>
-		<real>0.5372549019607843</real>
-	</dict>
-	<key>Ansi 9 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.5529411764705883</real>
-		<key>Green Component</key>
-		<real>0.4823529411764706</real>
-		<key>Red Component</key>
-		<real>0.7568627450980392</real>
-	</dict>
-	<key>Background Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.19215686274509805</real>
-		<key>Green Component</key>
-		<real>0.16470588235294117</real>
-		<key>Red Component</key>
-		<real>0.12549019607843137</real>
-	</dict>
-	<key>Bold Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7529411764705882</real>
-		<key>Green Component</key>
-		<real>0.6901960784313725</real>
-		<key>Red Component</key>
-		<real>0.6705882352941176</real>
-	</dict>
-	<key>Cursor Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7529411764705882</real>
-		<key>Green Component</key>
-		<real>0.6901960784313725</real>
-		<key>Red Component</key>
-		<real>0.6705882352941176</real>
-	</dict>
-	<key>Cursor Text Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.19215686274509805</real>
-		<key>Green Component</key>
-		<real>0.16470588235294117</real>
-		<key>Red Component</key>
-		<real>0.12549019607843137</real>
-	</dict>
-	<key>Foreground Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7529411764705882</real>
-		<key>Green Component</key>
-		<real>0.6901960784313725</real>
-		<key>Red Component</key>
-		<real>0.6705882352941176</real>
-	</dict>
-	<key>Selected Text Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7529411764705882</real>
-		<key>Green Component</key>
-		<real>0.6901960784313725</real>
-		<key>Red Component</key>
-		<real>0.6705882352941176</real>
-	</dict>
-	<key>Selection Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.19215686274509805</real>
-		<key>Green Component</key>
-		<real>0.16470588235294117</real>
-		<key>Red Component</key>
-		<real>0.12549019607843137</real>
-	</dict>
-</dict>
+  <dict>
+    <key>Ansi 0 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.19215686274509805</real>
+      <key>Green Component</key>
+      <real>0.16470588235294117</real>
+      <key>Red Component</key>
+      <real>0.12549019607843137</real>
+    </dict>
+    <key>Ansi 1 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.5529411764705883</real>
+      <key>Green Component</key>
+      <real>0.4823529411764706</real>
+      <key>Red Component</key>
+      <real>0.7568627450980392</real>
+    </dict>
+    <key>Ansi 10 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.3803921568627451</real>
+      <key>Green Component</key>
+      <real>0.592156862745098</real>
+      <key>Red Component</key>
+      <real>0.49019607843137253</real>
+    </dict>
+    <key>Ansi 11 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.3803921568627451</real>
+      <key>Green Component</key>
+      <real>0.5294117647058824</real>
+      <key>Red Component</key>
+      <real>0.6980392156862745</real>
+    </dict>
+    <key>Ansi 12 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.7411764705882353</real>
+      <key>Green Component</key>
+      <real>0.5882352941176471</real>
+      <key>Red Component</key>
+      <real>0.32941176470588235</real>
+    </dict>
+    <key>Ansi 13 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.7333333333333333</real>
+      <key>Green Component</key>
+      <real>0.5215686274509804</real>
+      <key>Red Component</key>
+      <real>0.6078431372549019</real>
+    </dict>
+    <key>Ansi 14 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.5647058823529412</real>
+      <key>Green Component</key>
+      <real>0.615686274509804</real>
+      <key>Red Component</key>
+      <real>0.27058823529411763</real>
+    </dict>
+    <key>Ansi 15 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.8588235294117647</real>
+      <key>Green Component</key>
+      <real>0.796078431372549</real>
+      <key>Red Component</key>
+      <real>0.7725490196078432</real>
+    </dict>
+    <key>Ansi 2 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.3803921568627451</real>
+      <key>Green Component</key>
+      <real>0.592156862745098</real>
+      <key>Red Component</key>
+      <real>0.49019607843137253</real>
+    </dict>
+    <key>Ansi 3 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.3803921568627451</real>
+      <key>Green Component</key>
+      <real>0.5294117647058824</real>
+      <key>Red Component</key>
+      <real>0.6980392156862745</real>
+    </dict>
+    <key>Ansi 4 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.7411764705882353</real>
+      <key>Green Component</key>
+      <real>0.5882352941176471</real>
+      <key>Red Component</key>
+      <real>0.32941176470588235</real>
+    </dict>
+    <key>Ansi 5 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.7333333333333333</real>
+      <key>Green Component</key>
+      <real>0.5215686274509804</real>
+      <key>Red Component</key>
+      <real>0.6078431372549019</real>
+    </dict>
+    <key>Ansi 6 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.5647058823529412</real>
+      <key>Green Component</key>
+      <real>0.615686274509804</real>
+      <key>Red Component</key>
+      <real>0.27058823529411763</real>
+    </dict>
+    <key>Ansi 7 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.7529411764705882</real>
+      <key>Green Component</key>
+      <real>0.6901960784313725</real>
+      <key>Red Component</key>
+      <real>0.6705882352941176</real>
+    </dict>
+    <key>Ansi 8 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.6196078431372549</real>
+      <key>Green Component</key>
+      <real>0.5607843137254902</real>
+      <key>Red Component</key>
+      <real>0.5372549019607843</real>
+    </dict>
+    <key>Ansi 9 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.5529411764705883</real>
+      <key>Green Component</key>
+      <real>0.4823529411764706</real>
+      <key>Red Component</key>
+      <real>0.7568627450980392</real>
+    </dict>
+    <key>Background Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.19215686274509805</real>
+      <key>Green Component</key>
+      <real>0.16470588235294117</real>
+      <key>Red Component</key>
+      <real>0.12549019607843137</real>
+    </dict>
+    <key>Bold Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.7529411764705882</real>
+      <key>Green Component</key>
+      <real>0.6901960784313725</real>
+      <key>Red Component</key>
+      <real>0.6705882352941176</real>
+    </dict>
+    <key>Cursor Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.7529411764705882</real>
+      <key>Green Component</key>
+      <real>0.6901960784313725</real>
+      <key>Red Component</key>
+      <real>0.6705882352941176</real>
+    </dict>
+    <key>Cursor Text Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.19215686274509805</real>
+      <key>Green Component</key>
+      <real>0.16470588235294117</real>
+      <key>Red Component</key>
+      <real>0.12549019607843137</real>
+    </dict>
+    <key>Foreground Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.7529411764705882</real>
+      <key>Green Component</key>
+      <real>0.6901960784313725</real>
+      <key>Red Component</key>
+      <real>0.6705882352941176</real>
+    </dict>
+    <key>Selected Text Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.19215686274509805</real>
+      <key>Green Component</key>
+      <real>0.16470588235294117</real>
+      <key>Red Component</key>
+      <real>0.12549019607843137</real>
+    </dict>
+    <key>Selection Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.7529411764705882</real>
+      <key>Green Component</key>
+      <real>0.6901960784313725</real>
+      <key>Red Component</key>
+      <real>0.6705882352941176</real>
+    </dict>
+  </dict>
 </plist>

--- a/terminals/iterm2/cosmic_latte_light.itermcolors
+++ b/terminals/iterm2/cosmic_latte_light.itermcolors
@@ -1,259 +1,259 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>Ansi 0 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9058823529411765</real>
-		<key>Green Component</key>
-		<real>0.9725490196078431</real>
-		<key>Red Component</key>
-		<real>1</real>
-	</dict>
-	<key>Ansi 1 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.33725490196078434</real>
-		<key>Green Component</key>
-		<real>0.2784313725490196</real>
-		<key>Red Component</key>
-		<real>0.7686274509803922</real>
-	</dict>
-	<key>Ansi 10 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.19607843137254902</real>
-		<key>Green Component</key>
-		<real>0.5137254901960784</real>
-		<key>Red Component</key>
-		<real>0.12156862745098039</real>
-	</dict>
-	<key>Ansi 11 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.011764705882352941</real>
-		<key>Green Component</key>
-		<real>0.42745098039215684</real>
-		<key>Red Component</key>
-		<real>0.5686274509803921</real>
-	</dict>
-	<key>Ansi 12 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.788235294117647</real>
-		<key>Green Component</key>
-		<real>0.4588235294117647</real>
-		<key>Red Component</key>
-		<real>0</real>
-	</dict>
-	<key>Ansi 13 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.6823529411764706</real>
-		<key>Green Component</key>
-		<real>0.32941176470588235</real>
-		<key>Red Component</key>
-		<real>0.6313725490196078</real>
-	</dict>
-	<key>Ansi 14 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.5411764705882353</real>
-		<key>Green Component</key>
-		<real>0.4980392156862745</real>
-		<key>Red Component</key>
-		<real>0</real>
-	</dict>
-	<key>Ansi 15 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.3137254901960784</real>
-		<key>Green Component</key>
-		<real>0.2823529411764706</real>
-		<key>Red Component</key>
-		<real>0.21176470588235294</real>
-	</dict>
-	<key>Ansi 2 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.19607843137254902</real>
-		<key>Green Component</key>
-		<real>0.5137254901960784</real>
-		<key>Red Component</key>
-		<real>0.12156862745098039</real>
-	</dict>
-	<key>Ansi 3 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.011764705882352941</real>
-		<key>Green Component</key>
-		<real>0.42745098039215684</real>
-		<key>Red Component</key>
-		<real>0.5686274509803921</real>
-	</dict>
-	<key>Ansi 4 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.788235294117647</real>
-		<key>Green Component</key>
-		<real>0.4588235294117647</real>
-		<key>Red Component</key>
-		<real>0</real>
-	</dict>
-	<key>Ansi 5 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.6823529411764706</real>
-		<key>Green Component</key>
-		<real>0.32941176470588235</real>
-		<key>Red Component</key>
-		<real>0.6313725490196078</real>
-	</dict>
-	<key>Ansi 6 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.5411764705882353</real>
-		<key>Green Component</key>
-		<real>0.4980392156862745</real>
-		<key>Red Component</key>
-		<real>0</real>
-	</dict>
-	<key>Ansi 7 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.3843137254901961</real>
-		<key>Green Component</key>
-		<real>0.35294117647058826</real>
-		<key>Red Component</key>
-		<real>0.2823529411764706</real>
-	</dict>
-	<key>Ansi 8 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.49411764705882355</real>
-		<key>Green Component</key>
-		<real>0.4588235294117647</real>
-		<key>Red Component</key>
-		<real>0.38823529411764707</real>
-	</dict>
-	<key>Ansi 9 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.33725490196078434</real>
-		<key>Green Component</key>
-		<real>0.2784313725490196</real>
-		<key>Red Component</key>
-		<real>0.7686274509803922</real>
-	</dict>
-	<key>Background Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9058823529411765</real>
-		<key>Green Component</key>
-		<real>0.9725490196078431</real>
-		<key>Red Component</key>
-		<real>1</real>
-	</dict>
-	<key>Bold Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.3843137254901961</real>
-		<key>Green Component</key>
-		<real>0.35294117647058826</real>
-		<key>Red Component</key>
-		<real>0.2823529411764706</real>
-	</dict>
-	<key>Cursor Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.3843137254901961</real>
-		<key>Green Component</key>
-		<real>0.35294117647058826</real>
-		<key>Red Component</key>
-		<real>0.2823529411764706</real>
-	</dict>
-	<key>Cursor Text Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9058823529411765</real>
-		<key>Green Component</key>
-		<real>0.9725490196078431</real>
-		<key>Red Component</key>
-		<real>1</real>
-	</dict>
-	<key>Foreground Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.3843137254901961</real>
-		<key>Green Component</key>
-		<real>0.35294117647058826</real>
-		<key>Red Component</key>
-		<real>0.2823529411764706</real>
-	</dict>
-	<key>Selected Text Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.3843137254901961</real>
-		<key>Green Component</key>
-		<real>0.35294117647058826</real>
-		<key>Red Component</key>
-		<real>0.2823529411764706</real>
-	</dict>
-	<key>Selection Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9058823529411765</real>
-		<key>Green Component</key>
-		<real>0.9725490196078431</real>
-		<key>Red Component</key>
-		<real>1</real>
-	</dict>
-</dict>
+  <dict>
+    <key>Ansi 0 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.9058823529411765</real>
+      <key>Green Component</key>
+      <real>0.9725490196078431</real>
+      <key>Red Component</key>
+      <real>1</real>
+    </dict>
+    <key>Ansi 1 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.33725490196078434</real>
+      <key>Green Component</key>
+      <real>0.2784313725490196</real>
+      <key>Red Component</key>
+      <real>0.7686274509803922</real>
+    </dict>
+    <key>Ansi 10 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.19607843137254902</real>
+      <key>Green Component</key>
+      <real>0.5137254901960784</real>
+      <key>Red Component</key>
+      <real>0.12156862745098039</real>
+    </dict>
+    <key>Ansi 11 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.011764705882352941</real>
+      <key>Green Component</key>
+      <real>0.42745098039215684</real>
+      <key>Red Component</key>
+      <real>0.5686274509803921</real>
+    </dict>
+    <key>Ansi 12 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.788235294117647</real>
+      <key>Green Component</key>
+      <real>0.4588235294117647</real>
+      <key>Red Component</key>
+      <real>0</real>
+    </dict>
+    <key>Ansi 13 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.6823529411764706</real>
+      <key>Green Component</key>
+      <real>0.32941176470588235</real>
+      <key>Red Component</key>
+      <real>0.6313725490196078</real>
+    </dict>
+    <key>Ansi 14 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.5411764705882353</real>
+      <key>Green Component</key>
+      <real>0.4980392156862745</real>
+      <key>Red Component</key>
+      <real>0</real>
+    </dict>
+    <key>Ansi 15 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.3137254901960784</real>
+      <key>Green Component</key>
+      <real>0.2823529411764706</real>
+      <key>Red Component</key>
+      <real>0.21176470588235294</real>
+    </dict>
+    <key>Ansi 2 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.19607843137254902</real>
+      <key>Green Component</key>
+      <real>0.5137254901960784</real>
+      <key>Red Component</key>
+      <real>0.12156862745098039</real>
+    </dict>
+    <key>Ansi 3 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.011764705882352941</real>
+      <key>Green Component</key>
+      <real>0.42745098039215684</real>
+      <key>Red Component</key>
+      <real>0.5686274509803921</real>
+    </dict>
+    <key>Ansi 4 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.788235294117647</real>
+      <key>Green Component</key>
+      <real>0.4588235294117647</real>
+      <key>Red Component</key>
+      <real>0</real>
+    </dict>
+    <key>Ansi 5 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.6823529411764706</real>
+      <key>Green Component</key>
+      <real>0.32941176470588235</real>
+      <key>Red Component</key>
+      <real>0.6313725490196078</real>
+    </dict>
+    <key>Ansi 6 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.5411764705882353</real>
+      <key>Green Component</key>
+      <real>0.4980392156862745</real>
+      <key>Red Component</key>
+      <real>0</real>
+    </dict>
+    <key>Ansi 7 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.3843137254901961</real>
+      <key>Green Component</key>
+      <real>0.35294117647058826</real>
+      <key>Red Component</key>
+      <real>0.2823529411764706</real>
+    </dict>
+    <key>Ansi 8 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.49411764705882355</real>
+      <key>Green Component</key>
+      <real>0.4588235294117647</real>
+      <key>Red Component</key>
+      <real>0.38823529411764707</real>
+    </dict>
+    <key>Ansi 9 Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.33725490196078434</real>
+      <key>Green Component</key>
+      <real>0.2784313725490196</real>
+      <key>Red Component</key>
+      <real>0.7686274509803922</real>
+    </dict>
+    <key>Background Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.9058823529411765</real>
+      <key>Green Component</key>
+      <real>0.9725490196078431</real>
+      <key>Red Component</key>
+      <real>1</real>
+    </dict>
+    <key>Bold Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.3843137254901961</real>
+      <key>Green Component</key>
+      <real>0.35294117647058826</real>
+      <key>Red Component</key>
+      <real>0.2823529411764706</real>
+    </dict>
+    <key>Cursor Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.3843137254901961</real>
+      <key>Green Component</key>
+      <real>0.35294117647058826</real>
+      <key>Red Component</key>
+      <real>0.2823529411764706</real>
+    </dict>
+    <key>Cursor Text Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.9058823529411765</real>
+      <key>Green Component</key>
+      <real>0.9725490196078431</real>
+      <key>Red Component</key>
+      <real>1</real>
+    </dict>
+    <key>Foreground Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.3843137254901961</real>
+      <key>Green Component</key>
+      <real>0.35294117647058826</real>
+      <key>Red Component</key>
+      <real>0.2823529411764706</real>
+    </dict>
+    <key>Selected Text Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.9058823529411765</real>
+      <key>Green Component</key>
+      <real>0.9725490196078431</real>
+      <key>Red Component</key>
+      <real>1</real>
+    </dict>
+    <key>Selection Color</key>
+    <dict>
+      <key>Color Space</key>
+      <string>sRGB</string>
+      <key>Blue Component</key>
+      <real>0.3843137254901961</real>
+      <key>Green Component</key>
+      <real>0.35294117647058826</real>
+      <key>Red Component</key>
+      <real>0.2823529411764706</real>
+    </dict>
+  </dict>
 </plist>


### PR DESCRIPTION
The text selection color was identical to the text foreground and background colors, making it hard to see highlighted text. This changes them to match the cursor colors.